### PR TITLE
Updated the extension paths and the run command in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This will build a custom Docker image for you with the extensions you provide in
 
 ```yaml
 extensions:
-  - name: github.com/treeder/fn-ext-example/logspam
-  - name: github.com/treeder/fn-ext-example/logspam2
+  - name: github.com/fnproject/fn-ext-example/logspam
+  - name: github.com/treeder/fn-ext-example2/logspam2
 ```
 
 Build it:
@@ -23,7 +23,7 @@ fn build-server -t imageuser/imagename
 Now run your new server:
 
 ```sh
-docker run --rm --name fnserver -it -v $PWD/data:/app/data -p 8080:8080 imageuser/imagename
+docker run --privileged --rm --name fnserver -it -v $PWD/data:/app/data -p 8080:8080 imageuser/imagename
 ```
 
 And deploy a function to try it out:


### PR DESCRIPTION
I noticed that the descirbed build-server command was not working because the example repositories were moved in GitHub. It works with the updated paths.

The run command wasn't working for me without the privileged flag. Therefore I added it to the run command example as it is described in https://github.com/fnproject/docs/blob/master/fn/operate/options.md